### PR TITLE
Implemented user authentication with GitHub OAuth and JWT

### DIFF
--- a/config/constanst.js
+++ b/config/constanst.js
@@ -1,0 +1,2 @@
+export const JWT_EXPIRATION = '7d';
+export const COOKIE_EXPIRATION = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds for the cookie

--- a/config/passport.js
+++ b/config/passport.js
@@ -1,0 +1,39 @@
+import passport from 'passport';
+import { Strategy as GitHubStrategy } from 'passport-github2';
+import User from '../models/userSchema.js';
+
+export default function (passport) {
+    passport.use(new GitHubStrategy({
+        clientID: process.env.GITHUB_CLIENT_ID,
+        clientSecret: process.env.GITHUB_CLIENT_SECRET,
+        callbackURL: "/api/auth/github/callback"
+    },
+    async (accessToken, refreshToken, profile, done) => {
+        const newUser = {
+            githubId: profile.id,
+            name: profile.displayName,
+            username: profile.username
+        }
+
+        try {
+            let user = await User.findOne({ githubId: profile.id });
+
+            if (user) {
+                done(null, user);
+            } else {
+                user = await User.create(newUser);
+                done(null, user);
+            }
+        } catch (err) {
+            console.error(err);
+        }
+    }));
+
+    passport.serializeUser((user, done) => {
+        done(null, user.id);
+    });
+
+    passport.deserializeUser((id, done) => {
+        User.findById(id, (err, user) => done(err, user));
+    });
+}

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -1,0 +1,81 @@
+import User from '../models/userSchema.js';
+import jwt from 'jsonwebtoken';
+import { JWT_EXPIRATION, COOKIE_EXPIRATION } from '../config/constants.js';
+
+const generateToken = (res, userId) => {
+  const token = jwt.sign({ userId }, process.env.JWT_SECRET, {
+    expiresIn: JWT_EXPIRATION,
+  });
+
+  res.cookie('jwt', token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV !== 'development',
+    sameSite: 'strict',
+    maxAge: COOKIE_EXPIRATION,
+  });
+};
+
+export const signup = async (req, res) => {
+  const { name, username, password } = req.body;
+
+  try {
+    const userExists = await User.findOne({ username });
+
+    if (userExists) {
+      return res.status(400).json({ message: 'User already exists' });
+    }
+
+    const user = await User.create({
+      name,
+      username,
+      password,
+    });
+
+    if (user) {
+      generateToken(res, user._id);
+      res.status(201).json({
+        _id: user._id,
+        name: user.name,
+        username: user.username,
+      });
+    } else {
+      res.status(400).json({ message: 'Invalid user data' });
+    }
+  } catch (error) {
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const login = async (req, res) => {
+  const { username, password } = req.body;
+
+  try {
+    const user = await User.findOne({ username });
+
+    if (user && (await user.matchPassword(password))) {
+      generateToken(res, user._id);
+      res.json({
+        _id: user._id,
+        name: user.name,
+        username: user.username,
+      });
+    } else {
+      res.status(401).json({ message: 'Invalid username or password' });
+    }
+  } catch (error) {
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const logout = (req, res) => {
+  res.cookie('jwt', '', {
+    httpOnly: true,
+    expires: new Date(0),
+  });
+  res.status(200).json({ message: 'Logged out successfully' });
+};
+
+export const githubCallback = (req, res) => {
+    generateToken(res, req.user._id);
+    res.redirect(process.env.FRONTEND_URL || '/'); // Redirect to the frontend application
+};

--- a/env.example
+++ b/env.example
@@ -4,3 +4,10 @@ MONGO_URI = mongodb://localhost:27017/algologs
 
 JWT_SECRET=supersecretkey
 JWT_EXPIRES_IN=7d
+
+# GitHub OAuth Credentials
+GITHUB_CLIENT_ID=your_github_client_id
+GITHUB_CLIENT_SECRET=your_github_client_secret
+
+# Frontend URL for redirects
+FRONTEND_URL=http://localhost:3000

--- a/middlewares/auth.middlewares.js
+++ b/middlewares/auth.middlewares.js
@@ -1,0 +1,20 @@
+import jwt from 'jsonwebtoken';
+import User from '../models/userSchema.js';
+
+export const protect = async (req, res, next) => {
+  let token;
+
+  token = req.cookies.jwt;
+
+  if (token) {
+    try {
+      const decoded = jwt.verify(token, process.env.JWT_SECRET);
+      req.user = await User.findById(decoded.userId).select('-password');
+      next();
+    } catch (error) {
+      res.status(401).json({ message: 'Not authorized, token failed' });
+    }
+  } else {
+    res.status(401).json({ message: 'Not authorized, no token' });
+  }
+};

--- a/models/userSchema.js
+++ b/models/userSchema.js
@@ -1,15 +1,41 @@
 import mongoose from 'mongoose';
+import bcrypt from 'bcryptjs';
 
 const userSchema = new mongoose.Schema({
-  githubId: String,
-  username: String,
-  githubToken: String,
-
+  name: {
+    type: String,
+    required: true,
+  },
+  username: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  password: {
+    type: String,
+  },
+  githubId: {
+    type: String,
+  },
   leetcodeUsername: String,
   gfgUsername: String,
   hackerrankUsername: String,
+}, { timestamps: true });
 
-  submissions: [submissionSchema]
+// Hash password before saving
+userSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) {
+    return next();
+  }
+  const salt = await bcrypt.genSalt(10);
+  this.password = await bcrypt.hash(this.password, salt);
+  next();
 });
 
-module.exports = mongoose.model('User', userSchema);
+// Method to compare passwords
+userSchema.methods.matchPassword = async function (enteredPassword) {
+  return await bcrypt.compare(enteredPassword, this.password);
+};
+
+const User = mongoose.model('User', userSchema);
+export default User;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,9 @@
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.17.0",
-        "nodemon": "^3.1.10"
+        "nodemon": "^3.1.10",
+        "passport": "^0.7.0",
+        "passport-github2": "^0.1.12"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -94,6 +96,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bcrypt": {
       "version": "6.0.0",
@@ -1201,6 +1212,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
+      "integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1252,6 +1269,63 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-github2": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.12.tgz",
+      "integrity": "sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.10.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
@@ -1260,6 +1334,11 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -1631,6 +1710,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
+      "license": "MIT"
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -1644,6 +1729,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.17.0",
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "passport": "^0.7.0",
+    "passport-github2": "^0.1.12"
   }
 }

--- a/routes/auth.routes.js
+++ b/routes/auth.routes.js
@@ -1,0 +1,21 @@
+import express from 'express';
+import { signup, login, logout, githubCallback } from '../controllers/auth.controller.js';
+import passport from 'passport';
+
+const router = express.Router();
+
+// Local Auth
+router.post('/signup', signup);
+router.post('/login', login);
+router.post('/logout', logout);
+
+// GitHub OAuth
+router.get('/github', passport.authenticate('github', { scope: ['user:email'] }));
+
+router.get(
+  '/github/callback',
+  passport.authenticate('github', { failureRedirect: '/login' }),
+  githubCallback
+);
+
+export default router;

--- a/server.js
+++ b/server.js
@@ -2,15 +2,33 @@ import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import path from 'path';
+import passport from 'passport';
+import cookieParser from 'cookie-parser';
 import connectDB from './config/connect.js';
+import authRoutes from './routes/auth.routes.js';
+import passportConfig from './config/passport.js';
+
 
 dotenv.config();
 const app = express();
+
+// Database connection
+connectDB();
+
+// Passport config
+passportConfig(passport);
+
+// Middlewares
 app.use(cors());
 app.use(express.json());
-connectDB();    
+app.use(express.urlencoded({ extended: false }));
+app.use(cookieParser());
+app.use(passport.initialize());
 
 const PORT = process.env.PORT || 3000;
+
+// Routes
+app.use('/api/auth', authRoutes);
 
 app.get('/', (req, res) => {
   res.send('Hello from Express!');


### PR DESCRIPTION
Introduce user authentication using GitHub OAuth alongside JWT for session management. This includes setting up routes for signup, login, and logout, as well as handling GitHub authentication callbacks. Additionally, configure middleware for protecting routes and manage user data in the database. To protect or authenticate a route, simply add the 'protect' middleware to it.

Added Dependencies : 
    "passport": "^0.7.0",
    "passport-github2": "^0.1.12"